### PR TITLE
Enable warning-less build on GCC and Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,7 @@ include(add_sources)
 
 # C++ definitions
 add_definitions(-std=c++14)
-add_definitions(-Weverything -Wall -Wextra -Wpedantic)
-include(silence_weverything)
+include(add_warnings)
 
 add_subdirectory(src)
 
@@ -17,6 +16,3 @@ declare_executable(emulator)
 find_package(SFML 2 REQUIRED system window graphics)
 include_directories(SYSTEM ${SFML_INCLUDE_DIR})
 target_link_libraries(emulator ${SFML_LIBRARIES})
-
-# FIXME: Temporarily silence warnings during development
-add_definitions(-Wno-missing-noreturn)

--- a/cmake/add_warnings.cmake
+++ b/cmake/add_warnings.cmake
@@ -1,0 +1,33 @@
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(extra_warn
+    -Weverything
+    -Wno-weak-vtables
+    -Wno-exit-time-destructors
+    -Wno-gnu-zero-variadic-macro-arguments
+    -Wno-global-constructors
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic)
+else()
+  set(extra_warn
+    -Wno-variadic-macros
+    -Wno-unknown-pragmas
+    -Wno-unused-variable)
+endif()
+
+set(all_warn
+  ${extra_warn}
+  -Wall
+  -Wextra
+  -Wpedantic
+  -Wno-padded
+  -Wno-format-nonliteral
+  -Wno-unused-parameter)
+
+# FIXME: Temporarily silence warnings during development
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  list(APPEND all_warn -Wno-missing-noreturn)
+else()
+  list(APPEND all_warn -Wno-return-type)
+endif()
+
+add_definitions(${all_warn})

--- a/cmake/silence_weverything.cmake
+++ b/cmake/silence_weverything.cmake
@@ -1,9 +1,0 @@
-# Disable unnecessary warnings from -Weverything
-add_definitions(-Wno-c++98-compat)
-add_definitions(-Wno-c++98-compat-pedantic)
-add_definitions(-Wno-padded)
-add_definitions(-Wno-global-constructors)
-add_definitions(-Wno-gnu-zero-variadic-macro-arguments)
-add_definitions(-Wno-format-nonliteral)
-add_definitions(-Wno-exit-time-destructors)
-add_definitions(-Wno-weak-vtables)

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -18,6 +18,8 @@
 
 #include "string.h"
 
+#include <cstdarg>
+
 Logger global_logger;
 const char* COLOR_TRACE = "\033[1;30m";
 const char* COLOR_DEBUG = "\033[1;37m";

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -54,11 +54,16 @@ extern const char* COLOR_WARNING;
 extern const char* COLOR_ERROR;
 extern const char* COLOR_RESET;
 
-#define log_trace(fmt, ...) global_logger.log(LogLevel::Trace, fmt, ##__VA_ARGS__);
-#define log_debug(fmt, ...) global_logger.log(LogLevel::Debug, fmt, ##__VA_ARGS__);
-#define log_unimplemented(fmt, ...) global_logger.log(LogLevel::Unimplemented, fmt, ##__VA_ARGS__);
-#define log_info(fmt, ...) global_logger.log(LogLevel::Info, fmt, ##__VA_ARGS__);
-#define log_warn(fmt, ...) global_logger.log(LogLevel::Warning, fmt, ##__VA_ARGS__);
-#define log_error(fmt, ...) global_logger.log(LogLevel::Error, fmt, ##__VA_ARGS__);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+#define log_trace(...) global_logger.log(LogLevel::Trace, ##__VA_ARGS__);
+#define log_debug(...) global_logger.log(LogLevel::Debug, ##__VA_ARGS__);
+#define log_unimplemented(...) global_logger.log(LogLevel::Unimplemented, ##__VA_ARGS__);
+#define log_info(...) global_logger.log(LogLevel::Info, ##__VA_ARGS__);
+#define log_warn(...) global_logger.log(LogLevel::Warning, ##__VA_ARGS__);
+#define log_error(...) global_logger.log(LogLevel::Error, ##__VA_ARGS__);
+
+#pragma clang diagnostic pop
 
 extern void log_set_level(LogLevel level);

--- a/src/util/string.cc
+++ b/src/util/string.cc
@@ -3,6 +3,8 @@
 #include <cstdio>
 #include <sstream>
 
+#include <cstdarg>
+
 using std::string;
 using std::vector;
 


### PR DESCRIPTION
Fix issues with GCC build and ensure warning-less build on both
GCC and Clang.

Fixes #1